### PR TITLE
[EXTERNAL] fix(numpy): clarify that CSV header is excluded when loading data

### DIFF
--- a/subjects/ai/numpy/README.md
+++ b/subjects/ai/numpy/README.md
@@ -296,7 +296,7 @@ The goal of this exercise is to perform fundamental data analysis on real data u
 
 The dataset chosen for this task was the [red wine dataset](./data/winequality-red.csv). You can find more info [HERE](./data/)
 
-1. Load the data using `genfromtxt`, specifying the delimiter as ';', and optimize the numpy array size by reducing the data types. Use `np.float32` and verify that the resulting numpy array weighs **76800 bytes**.
+1. Load the data using `genfromtxt`, specifying the delimiter as ';' with excluding the headers, and optimize the numpy array size by reducing the data types. Use `np.float32` and verify that the resulting numpy array weighs **76800 bytes**.
 
 2. Display the 2nd, 7th, and 12th rows as a two-dimensional array. Exclude `np.nan` values if present.
 


### PR DESCRIPTION
### Fix ambiguous instruction about row indexing

#### What changed

The sentence:

> "Load the data using genfromtxt, specifying the delimiter as ';', and optimize the numpy array size by reducing the data types. Use np.float32 and verify that the resulting numpy array weighs 76800 bytes."

was unclear about whether the CSV header should be skipped or not.

It now says:

> "Load the data using genfromtxt, specifying the delimiter as ';' with excluding the headers, and optimize the numpy array size by reducing the data types. Use np.float32 and verify that the resulting numpy array weighs 76800 bytes."

#### Why

Later instructions refer to specific row numbers (like the 2nd, 7th, and 12th rows). Without stating whether the header counts as a row, the meaning is ambiguous — it affects the indexing. This fix makes it clear that the header should be excluded.

#### No code changes

This is a documentation fix only.
